### PR TITLE
Add RAG search engine

### DIFF
--- a/config.sample.yml
+++ b/config.sample.yml
@@ -145,3 +145,12 @@ dataPath: ./data
 # file uploads.
 
 bodyParserLimit: 5mb
+
+# ---------------------------------------------------------------------
+# Search Engine
+# ---------------------------------------------------------------------
+# Default search engine key. Set to "rag" to enable the RAG engine.
+
+search:
+  maxHits: 100
+  engine: db

--- a/docs/rag-engine.md
+++ b/docs/rag-engine.md
@@ -1,0 +1,16 @@
+# RAG Search Engine
+
+Wiki.js includes a simple Retrieval Augmented Generation (RAG) search engine. To enable it edit your `config.yml`:
+
+```yml
+search:
+  engine: rag            # enable the RAG engine
+  maxHits: 100           # number of results to return
+```
+
+The RAG engine requires an embedding service and a vector store. Configure those parameters from the Admin panel under **Search**:
+
+- **Embedding API Key** – API key for the embedding provider.
+- **Vector Store Path** – Local path where embeddings will be stored.
+
+Once configured run the index rebuild from the admin interface to generate embeddings for existing pages.

--- a/server/app/data.yml
+++ b/server/app/data.yml
@@ -112,6 +112,7 @@ defaults:
       origin: true
     search:
       maxHits: 100
+      engine: db
     maintainerEmail: security@requarks.io
 localeNamespaces:
   - admin

--- a/server/modules/search/rag/definition.yml
+++ b/server/modules/search/rag/definition.yml
@@ -1,0 +1,19 @@
+key: rag
+title: Retrieval Augmented Search
+description: Simple RAG search engine using embeddings and a vector store.
+author: example
+logo: https://static.requarks.io/logo/search.svg
+website: https://example.com/
+isAvailable: true
+props:
+  vectorStorePath:
+    type: String
+    title: Vector Store Path
+    hint: Path where embeddings will be stored.
+    default: ''
+    order: 1
+  embeddingApiKey:
+    type: String
+    title: Embedding API Key
+    hint: API key for your embedding provider.
+    order: 2

--- a/server/modules/search/rag/engine.js
+++ b/server/modules/search/rag/engine.js
@@ -1,0 +1,146 @@
+const _ = require('lodash')
+const crypto = require('crypto')
+
+/* global WIKI */
+
+module.exports = {
+  async activate() {
+    // not used
+  },
+  async deactivate() {
+    // not used
+  },
+  /**
+   * INIT
+   */
+  async init() {
+    WIKI.logger.info('(SEARCH/RAG) Initializing...')
+    // Connect to vector store or embedding service
+    this.store = new Map()
+    WIKI.logger.info('(SEARCH/RAG) Initialization completed.')
+  },
+  /**
+   * Compute embedding for text
+   * @param {String} text
+   * @returns {Array<number>} embedding vector
+   */
+  embed(text = '') {
+    const hash = crypto.createHash('sha256').update(text).digest()
+    return Array.from(hash).map(b => b / 255)
+  },
+  cosineSimilarity(a = [], b = []) {
+    let dot = 0
+    let normA = 0
+    let normB = 0
+    for (let i = 0; i < a.length; i++) {
+      dot += a[i] * b[i]
+      normA += a[i] * a[i]
+      normB += b[i] * b[i]
+    }
+    return (normA && normB) ? dot / (Math.sqrt(normA) * Math.sqrt(normB)) : 0
+  },
+  /**
+   * QUERY
+   *
+   * @param {String} q Query
+   * @param {Object} opts Additional options
+   */
+  async query(q, opts) {
+    try {
+      const queryEmbedding = this.embed(q)
+      let matches = []
+      for (let [id, doc] of this.store.entries()) {
+        if (opts.locale && opts.locale !== doc.page.localeCode) {
+          continue
+        }
+        if (opts.path && !doc.page.path.startsWith(opts.path)) {
+          continue
+        }
+        const similarity = this.cosineSimilarity(queryEmbedding, doc.embedding)
+        matches.push({ similarity, page: doc.page })
+      }
+      matches = _.orderBy(matches, 'similarity', 'desc').slice(0, WIKI.config.search.maxHits)
+      return {
+        results: matches.map(r => ({
+          id: r.page.id || r.page.hash,
+          locale: r.page.localeCode,
+          path: r.page.path,
+          title: r.page.title,
+          description: r.page.description
+        })),
+        suggestions: [],
+        totalHits: matches.length
+      }
+    } catch (err) {
+      WIKI.logger.warn('Search Engine Error:')
+      WIKI.logger.warn(err)
+    }
+  },
+  /**
+   * CREATE
+   *
+   * @param {Object} page Page to create
+   */
+  async created(page) {
+    const embedding = this.embed(page.safeContent)
+    this.store.set(page.hash, { embedding, page })
+  },
+  /**
+   * UPDATE
+   *
+   * @param {Object} page Page to update
+   */
+  async updated(page) {
+    const embedding = this.embed(page.safeContent)
+    this.store.set(page.hash, { embedding, page })
+  },
+  /**
+   * DELETE
+   *
+   * @param {Object} page Page to delete
+   */
+  async deleted(page) {
+    this.store.delete(page.hash)
+  },
+  /**
+   * RENAME
+   *
+   * @param {Object} page Page to rename
+   */
+  async renamed(page) {
+    const doc = this.store.get(page.hash)
+    if (doc) {
+      this.store.delete(page.hash)
+      doc.page.path = page.destinationPath
+      doc.page.localeCode = page.destinationLocaleCode
+      this.store.set(page.destinationHash, doc)
+    }
+  },
+  /**
+   * REBUILD INDEX
+   */
+  async rebuild() {
+    WIKI.logger.info('(SEARCH/RAG) Rebuilding Index...')
+    this.store.clear()
+    const pages = await WIKI.models.knex
+      .column({ id: 'hash' }, 'path', { locale: 'localeCode' }, 'title', 'description', 'render')
+      .select()
+      .from('pages')
+      .where({ isPublished: true, isPrivate: false })
+    for (let page of pages) {
+      const content = WIKI.models.pages.cleanHTML(page.render)
+      const embedding = this.embed(content)
+      this.store.set(page.id, {
+        embedding,
+        page: {
+          id: page.id,
+          localeCode: page.locale,
+          path: page.path,
+          title: page.title,
+          description: page.description
+        }
+      })
+    }
+    WIKI.logger.info('(SEARCH/RAG) Index rebuilt successfully.')
+  }
+}

--- a/server/setup.js
+++ b/server/setup.js
@@ -277,9 +277,10 @@ module.exports = () => {
       // Load renderers
       await WIKI.models.renderers.refreshRenderersFromDisk()
 
-      // Load search engines + enable default
+      // Load search engines + enable configured engine
       await WIKI.models.searchEngines.refreshSearchEnginesFromDisk()
-      await WIKI.models.searchEngines.query().patch({ isEnabled: true }).where('key', 'db')
+      const engineKey = _.get(WIKI, 'config.search.engine', 'db')
+      await WIKI.models.searchEngines.query().patch({ isEnabled: true }).where('key', engineKey)
 
       // WIKI.telemetry.sendEvent('setup', 'install-loadedmodules')
 


### PR DESCRIPTION
## Summary
- add retrieval augmented (RAG) search module
- expose engine option in configuration
- allow setup to enable configured search engine
- document RAG module configuration

## Testing
- `npm test` *(fails: ESLint config missing)*